### PR TITLE
feat: デザイナー募集のお問い合わせ種別を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"lint": "prettier --check . && eslint .",
 		"lint:prettier": "prettier --check .",
 		"lint:eslint": "eslint .",
-		"precommit": "npm-run-all --parallel check lint:*"
+		"test": "node --import tsx tests/validator.test.ts",
+		"precommit": "npm-run-all --parallel check lint:* test"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.6",

--- a/src/routes/emailSender.ts
+++ b/src/routes/emailSender.ts
@@ -1,13 +1,6 @@
 import { Resend } from 'resend';
-import { categories, type CategoryKey, type RequestBody } from './validator';
+import { categories, ccsByCategory, type RequestBody } from './validator';
 import { env } from '$env/dynamic/private';
-
-const ccsByCategory: Record<string, string[]> = {
-	'concert, ticket': ['webadmin@orch-canvas.tokyo', 'info@orch-canvas.tokyo'],
-	advertisement: ['webadmin@orch-canvas.tokyo', 'pr@orch-canvas.tokyo'],
-	'hp, sns': ['webadmin@orch-canvas.tokyo'],
-	others: ['webadmin@orch-canvas.tokyo', 'contact@orch-canvas.tokyo']
-} as Record<CategoryKey, string[]>;
 
 export async function sendEmail(content: RequestBody, apiKey: string) {
 	const subject = 'お問い合わせを承りました（Orchestra Canvas Tokyo）';

--- a/src/routes/validator.ts
+++ b/src/routes/validator.ts
@@ -6,7 +6,7 @@ export const statusScheme = z
 export type Status = z.infer<typeof statusScheme>;
 
 const categoryKeyScheme = z
-	.enum(['concert, ticket', 'advertisement', 'hp, sns', 'others'])
+	.enum(['concert, ticket', 'advertisement', 'hp, sns', 'designer', 'others'])
 	.brand<'Category'>();
 export type CategoryKey = z.infer<typeof categoryKeyScheme>;
 
@@ -14,8 +14,17 @@ export const categories: Record<string, string> = {
 	'concert, ticket': '演奏会、チケットについて',
 	advertisement: '挟み込みについて',
 	'hp, sns': 'ホームページ、SNSについて',
+	designer: 'デザイナー募集について',
 	others: 'その他'
 } as Record<CategoryKey, string>;
+
+export const ccsByCategory: Record<string, string[]> = {
+	'concert, ticket': ['webadmin@orch-canvas.tokyo', 'info@orch-canvas.tokyo'],
+	advertisement: ['webadmin@orch-canvas.tokyo', 'pr@orch-canvas.tokyo'],
+	'hp, sns': ['webadmin@orch-canvas.tokyo'],
+	designer: ['webadmin@orch-canvas.tokyo', 'kouhou@orch-canvas.tokyo'],
+	others: ['webadmin@orch-canvas.tokyo', 'contact@orch-canvas.tokyo']
+} as Record<CategoryKey, string[]>;
 
 export const maxBodyLength = 1000;
 

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1,0 +1,30 @@
+import * as validator from '../src/routes/validator';
+
+function assert(condition: boolean, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
+const result = validator.validate({
+	name: 'テスト太郎',
+	email: 'test@example.com',
+	categoryKey: 'designer',
+	body: 'デザイナー募集について問い合わせます。',
+	csrfToken: '123e4567-e89b-12d3-a456-426614174000',
+	reCaptchaToken: 'test-token'
+});
+
+assert(result.success, 'デザイナー募集のお問い合わせがバリデーションを通過しませんでした');
+assert(
+	validator.categories[result.data.categoryKey] === 'デザイナー募集について',
+	'お問い合わせ種別の表示名が一致しませんでした'
+);
+
+const recipients = validator.ccsByCategory[result.data.categoryKey];
+assert(
+	recipients.length === 2 &&
+		recipients[0] === 'webadmin@orch-canvas.tokyo' &&
+		recipients[1] === 'kouhou@orch-canvas.tokyo',
+	'デザイナー募集のお問い合わせ先が一致しませんでした'
+);
+
+console.log('デザイナー募集のお問い合わせ種別と転送先を確認しました');


### PR DESCRIPTION
## 概要

- お問い合わせ種別に「デザイナー募集について」を追加
- 本番環境の `cc` / `replyTo` を次の2件に設定
  - `webadmin@orch-canvas.tokyo`
  - `kouhou@orch-canvas.tokyo`
- 種別の入力検証・表示名・転送先を確認する回帰テストを追加

## 背景

デザイナー募集期間中のお問い合わせを広報担当へ転送するための一時的な変更です。

## 影響

フォームの選択肢、確認メール内の分類、Slack通知内の分類に新しい種別が反映されます。DBマイグレーションは不要です。

## 検証

- `npm test`
- `SESSION_SECRET=test RECAPTCHA_SECRET=test RESEND_API_KEY=test npm run precommit`
- `SESSION_SECRET=test RECAPTCHA_SECRET=test RESEND_API_KEY=test npm run build`

## 一時変更

対応するrevert PR: #5

PR #5はこのPRのマージ後に最新の `main` へ載せ替えて使用します。